### PR TITLE
Add drag-and-drop tasks and tag palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a SvelteKit based application for tracking tasks with timed active periods.
 
-Core requirements are documented in [docs/README.md](docs/README.md) with a brief summary in [docs/CORE_REQUIREMENTS.md](docs/CORE_REQUIREMENTS.md). A short readme is also available at [CORE_REQUIREMENTS_README.md](CORE_REQUIREMENTS_README.md).
+Core requirements are documented in [docs/README.md](docs/README.md) with a brief summary in [docs/CORE_REQUIREMENTS.md](docs/CORE_REQUIREMENTS.md). Short summaries are available at [CORE_REQUIREMENTS_README.md](CORE_REQUIREMENTS_README.md) and [docs/CORE_SUMMARY.md](docs/CORE_SUMMARY.md).
 Component stubs are detailed in [docs/components.md](docs/components.md).
 
 ---

--- a/docs/CORE_SUMMARY.md
+++ b/docs/CORE_SUMMARY.md
@@ -1,0 +1,13 @@
+# Core Requirements Summary
+
+This short document lists the key behaviors of the TODO Timer Dashboard as described in the project documentation.
+
+- Only **one task** may be active at a time.
+- Tasks move between the To‑Do list, Active box and Cleared list using drag and drop.
+- Tasks in the To‑Do list can be reordered by dragging.
+- Use the `Add new task` field to create tasks, including optional `#tags` and `!` priority flags.
+- Each task accumulates time spent active per day. Timers pause at your configured day end and resume the next day.
+- The Recap view shows activity for different days via a date picker.
+- All tags are shown in a palette. Drag a tag onto a task to assign it, or right‑click a tag to edit its colours.
+
+For more detailed explanations, see [`docs/README.md`](README.md) and [`CORE_REQUIREMENTS.md`](CORE_REQUIREMENTS.md).

--- a/src/lib/components/ActiveTask.svelte
+++ b/src/lib/components/ActiveTask.svelte
@@ -1,17 +1,55 @@
 <script lang="ts">
   import type { TodoTask } from '$lib/types';
+  import { activateTask, tagStyles } from '$lib';
+  import { get } from 'svelte/store';
   export let task: TodoTask | null = null;
 </script>
 
-<section class="active-task">
+<section
+  class="active-task"
+  on:dragover|preventDefault
+  on:drop={(e) => {
+    const id = e.dataTransfer.getData('text/task');
+    if (id) activateTask(id);
+  }}
+>
   {#if task}
-    <h2>{task.title}</h2>
-    <p>Active for: <!-- timer placeholder --></p>
+    <div
+      class="current"
+      draggable="true"
+      on:dragstart={(e) => e.dataTransfer.setData('text/active', task.id)}
+    >
+      <h2>{task.title}</h2>
+      <div class="tags">
+        {#each task.tags as tag}
+          <span
+            class="tag-pill"
+            style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[tag]?.fg};border-color:{get(tagStyles)[tag]?.border}"
+            >{tag}</span
+          >
+        {/each}
+      </div>
+    </div>
   {:else}
     <p>No active task</p>
   {/if}
 </section>
 
 <style>
-.active-task { padding: 1rem; border: 1px solid currentColor; }
+.active-task {
+  padding: 1rem;
+  border: 1px solid currentColor;
+  min-height: 3rem;
+}
+.current {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.tag-pill {
+  padding: 0.1rem 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 0.7rem;
+}
 </style>

--- a/src/lib/components/ClearedList.svelte
+++ b/src/lib/components/ClearedList.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import type { TodoTask } from '$lib/types';
+  import { clearTask } from '$lib';
   export let tasks: TodoTask[] = [];
 </script>
 
 <section class="cleared-list">
   <h2>Cleared</h2>
-  <ul>
+  <ul
+    on:dragover|preventDefault
+    on:drop={(e) => {
+      const activeId = e.dataTransfer.getData('text/active');
+      if (activeId) clearTask(activeId);
+    }}
+  >
     {#each tasks as t}
       <li>{t.title}</li>
     {/each}

--- a/src/lib/components/TagsList.svelte
+++ b/src/lib/components/TagsList.svelte
@@ -1,16 +1,76 @@
 <script lang="ts">
+  import { tagStyles } from '$lib';
+  import { get } from 'svelte/store';
+
   export let tags: string[] = [];
+
+  let editTag: string | null = null;
+  let newName = '';
+  let bg = '#eee';
+  let fg = '#000';
+  let border = '#ccc';
+
+  function startEdit(tag: string) {
+    const style = get(tagStyles)[tag] || { bg: '#eee', fg: '#000', border: '#ccc' };
+    editTag = tag;
+    newName = tag;
+    bg = style.bg;
+    fg = style.fg;
+    border = style.border;
+  }
+
+  function saveEdit() {
+    if (!editTag) return;
+    tagStyles.update((styles) => {
+      delete styles[editTag!];
+      styles[newName] = { name: newName, bg, fg, border };
+      return styles;
+    });
+    editTag = null;
+  }
 </script>
 
 <section class="tags-list">
   <h2>Tags</h2>
-  <ul>
+  <div class="palette">
     {#each tags as tag}
-      <li>{tag}</li>
+      <span
+        class="tag-pill"
+        style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[tag]?.fg};border-color:{get(tagStyles)[tag]?.border}"
+        draggable="true"
+        on:contextmenu|preventDefault={() => startEdit(tag)}
+        on:dragstart={(e) => e.dataTransfer.setData('text/tag', tag)}
+        >{tag}</span
+      >
     {/each}
-  </ul>
+  </div>
+
+  {#if editTag}
+    <div class="edit-dialog">
+      <input type="text" bind:value={newName} />
+      <input type="color" bind:value={bg} />
+      <input type="color" bind:value={fg} />
+      <input type="color" bind:value={border} />
+      <button on:click={saveEdit}>Save</button>
+      <button on:click={() => (editTag = null)}>Cancel</button>
+    </div>
+  {/if}
 </section>
 
 <style>
 .tags-list { padding: 1rem; }
+.palette { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+.tag-pill {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  user-select: none;
+  cursor: grab;
+}
+.edit-dialog {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+}
 </style>

--- a/src/lib/components/TodoList.svelte
+++ b/src/lib/components/TodoList.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
   import type { TodoTask } from '$lib/types';
-  import { addTask } from '$lib';
+  import {
+    addTask,
+    activateTask,
+    deactivateTask,
+    reorderTodo,
+    tagStyles,
+    tasks as tasksStore
+  } from '$lib';
+  import { get } from 'svelte/store';
   export let tasks: TodoTask[] = [];
 
   let newTask = '';
@@ -13,15 +21,52 @@
 
 <section class="todo-list">
   <h2>To-Do</h2>
-  <ul>
+  <ul
+    on:dragover|preventDefault
+    on:drop={(e) => {
+      const id = e.dataTransfer.getData('text/task');
+      const activeId = e.dataTransfer.getData('text/active');
+      if (id) reorderTodo(id, null);
+      if (activeId) deactivateTask(activeId);
+    }}
+  >
     {#each tasks as t}
-      <li>{t.title}</li>
+      <li
+        class="task-row"
+        draggable="true"
+        on:dragstart={(e) => e.dataTransfer.setData('text/task', t.id)}
+        on:dragover|preventDefault={() => {}}
+        on:drop={(e) => {
+          const id = e.dataTransfer.getData('text/task');
+          if (id && id !== t.id) reorderTodo(id, t.id);
+          const tag = e.dataTransfer.getData('text/tag');
+          if (tag && !t.tags.includes(tag)) {
+            tasksStore.update((list) => {
+              const task = list.find((x) => x.id === t.id);
+              if (task) task.tags = [...task.tags, tag];
+              return [...list];
+            });
+          }
+        }}
+      >
+        <span class="priority"></span>
+        <span class="title">{t.title}</span>
+        <span class="tags">
+          {#each t.tags as tag}
+            <span
+              class="tag-pill"
+              style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[tag]?.fg};border-color:{get(tagStyles)[tag]?.border}"
+              >{tag}</span
+            >
+          {/each}
+        </span>
+      </li>
     {/each}
   </ul>
   <div class="add-bar">
     <input
       type="text"
-      placeholder="Add new task (#tag)"
+      placeholder="Add new task (#tag for tags)"
       bind:value={newTask}
       on:keydown={(e) => e.key === 'Enter' && submit()}
     />
@@ -31,6 +76,37 @@
 
 <style>
 .todo-list { padding: 1rem; }
+.task-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  margin-bottom: 0.25rem;
+  background: var(--bg-box);
+  border: 1px solid var(--border);
+}
+.task-row .priority {
+  width: 0.75rem;
+  height: 0.75rem;
+  background: #888;
+  margin-right: 0.5rem;
+  border-radius: 0.1rem;
+}
+.task-row .title {
+  flex: 1;
+}
+.task-row .tags {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+.tag-pill {
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  font-size: 0.7rem;
+}
 .add-bar {
   margin-top: 0.5rem;
   display: flex;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './components';
 export * from './stores/settings';
 export * from './stores/tasks';
+export * from "./stores/tagStyles";

--- a/src/lib/stores/tagStyles.ts
+++ b/src/lib/stores/tagStyles.ts
@@ -1,0 +1,37 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+export interface TagStyle {
+  name: string;
+  bg: string;
+  fg: string;
+  border: string;
+}
+
+function createTagStyles() {
+  const initial: Record<string, TagStyle> =
+    browser && localStorage.getItem('tagStyles')
+      ? JSON.parse(localStorage.getItem('tagStyles')!)
+      : {};
+
+  const store = writable<Record<string, TagStyle>>(initial);
+
+  if (browser) {
+    store.subscribe((val) => {
+      localStorage.setItem('tagStyles', JSON.stringify(val));
+    });
+  }
+
+  return store;
+}
+
+export const tagStyles = createTagStyles();
+
+export function ensureTagStyle(name: string) {
+  tagStyles.update((styles) => {
+    if (!styles[name]) {
+      styles[name] = { name, bg: '#eee', fg: '#000', border: '#ccc' };
+    }
+    return styles;
+  });
+}

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { TodoTask } from '$lib/types';
+import { ensureTagStyle } from './tagStyles';
 
 /** Parse an input string and extract tags prefixed with '#'.
  * Returns the cleaned title and array of tags.
@@ -9,6 +10,7 @@ function parseInput(input: string): { title: string; tags: string[] } {
   const tags: string[] = [];
   const withoutTags = input.replace(/#([A-Za-z0-9_-]+)/g, (_, tag) => {
     tags.push(tag);
+    ensureTagStyle(tag);
     return '';
   });
   return { title: withoutTags.trim(), tags };
@@ -34,6 +36,8 @@ function createTasks() {
       ? JSON.parse(localStorage.getItem('tasks')!)
       : [];
 
+  initial.forEach((t) => t.tags.forEach((tag) => ensureTagStyle(tag)));
+
   const store = writable<TodoTask[]>(initial);
 
   if (browser) {
@@ -46,6 +50,71 @@ function createTasks() {
 }
 
 export const tasks = createTasks();
+
+export function activateTask(id: string) {
+  const now = Date.now();
+  tasks.update((list) => {
+    // End any current active task
+    list.forEach((t) => {
+      const last = t.activePeriods[t.activePeriods.length - 1];
+      if (last && last.end === null) {
+        last.end = now;
+      }
+    });
+
+    const task = list.find((t) => t.id === id);
+    if (task) {
+      task.activePeriods.push({ start: now, end: null });
+      task.updatedAt = now;
+    }
+    return [...list];
+  });
+}
+
+export function deactivateTask(id: string) {
+  const now = Date.now();
+  tasks.update((list) => {
+    const task = list.find((t) => t.id === id);
+    if (task) {
+      const last = task.activePeriods[task.activePeriods.length - 1];
+      if (last && last.end === null) {
+        last.end = now;
+      }
+      task.updatedAt = now;
+    }
+    return [...list];
+  });
+}
+
+export function clearTask(id: string) {
+  tasks.update((list) => {
+    const task = list.find((t) => t.id === id);
+    if (task) {
+      task.isDone = true;
+      const last = task.activePeriods[task.activePeriods.length - 1];
+      if (last && last.end === null) {
+        last.end = Date.now();
+      }
+    }
+    return [...list];
+  });
+}
+
+export function reorderTodo(id: string, beforeId: string | null) {
+  tasks.update((list) => {
+    const idx = list.findIndex((t) => t.id === id);
+    if (idx === -1) return list;
+    const [task] = list.splice(idx, 1);
+    if (beforeId) {
+      const targetIndex = list.findIndex((t) => t.id === beforeId);
+      if (targetIndex === -1) list.push(task);
+      else list.splice(targetIndex, 0, task);
+    } else {
+      list.push(task);
+    }
+    return [...list];
+  });
+}
 
 /** Add a new task from an input string. */
 export function addTask(input: string): void {


### PR DESCRIPTION
## Summary
- support tag styling and editing with new `tagStyles` store
- enable drag & drop reordering and tagging in `TodoList`
- make `ActiveTask` and `ClearedList` accept drag events
- style tags consistently and allow palette editing
