### PR TITLE
Add detailed active task UI

### DIFF
--- a/docs/CORE_REQUIREMENTS_OVERVIEW.md
+++ b/docs/CORE_REQUIREMENTS_OVERVIEW.md
@@ -1,0 +1,12 @@
+# Documents Core Requirements Overview
+
+This overview summarises the main behaviours of the TODO Timer Dashboard as documented in `docs/CORE_REQUIREMENTS.md`.
+
+- Only **one task** can be active at a time.
+- Drag tasks between the To‑Do list, Active area and Cleared list.
+- New tasks are added via the `Add new task` field using `#tag` for tags and `!` for priority.
+- Each task records how long it has been active today. Timers pause at the configured end of day.
+- The Recap view lets you inspect previous days.
+- All tags used appear in the Tags panel where they can be assigned to tasks.
+
+See the full requirements in [CORE_REQUIREMENTS.md](CORE_REQUIREMENTS.md).

--- a/src/lib/components/AdvancedDetails.svelte
+++ b/src/lib/components/AdvancedDetails.svelte
@@ -1,17 +1,139 @@
 <script lang="ts">
   import type { TodoTask } from '$lib/types';
+  import { tagStyles, tasks as tasksStore, settings } from '$lib';
+  import { get } from 'svelte/store';
+  import { onMount, onDestroy } from 'svelte';
+
   export let task: TodoTask | null = null;
+
+  let now = Date.now();
+  let timer: ReturnType<typeof setInterval>;
+
+  onMount(() => {
+    timer = setInterval(() => (now = Date.now()), 60000);
+  });
+  onDestroy(() => clearInterval(timer));
+
+  function formatDuration(ms: number): string {
+    const sec = Math.floor(ms / 1000);
+    const h = Math.floor(sec / 3600)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor((sec % 3600) / 60)
+      .toString()
+      .padStart(2, '0');
+    const s = Math.floor(sec % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${h}:${m}:${s}`;
+  }
+
+  $: totalTime = task
+    ? task.activePeriods.reduce(
+        (sum, p) => sum + ((p.end ?? now) - p.start),
+        0
+      )
+    : 0;
+
+  $: dayStart = (() => {
+    const { dayStart } = get(settings);
+    const [h, m] = dayStart.split(':').map(Number);
+    return new Date().setHours(h, m, 0, 0);
+  })();
+  $: dayEnd = (() => {
+    const { dayEnd } = get(settings);
+    const [h, m] = dayEnd.split(':').map(Number);
+    return new Date().setHours(h, m, 0, 0);
+  })();
+
+  $: totalToday = task
+    ? task.activePeriods.reduce((sum, p) => {
+        const start = Math.max(p.start, dayStart);
+        const end = Math.min(p.end ?? now, dayEnd);
+        return end > start ? sum + (end - start) : sum;
+      }, 0)
+    : 0;
+
+  function removeTag(tag: string) {
+    if (!task) return;
+    tasksStore.update((list) => {
+      const t = list.find((x) => x.id === task!.id);
+      if (t) t.tags = t.tags.filter((tg) => tg !== tag);
+      return [...list];
+    });
+  }
 </script>
 
 <section class="advanced-details">
-  <h2>Details</h2>
   {#if task}
+    <div class="header">
+      <h3>{task.title}</h3>
+      <span class="time">{formatDuration(totalTime)}</span>
+    </div>
     <textarea placeholder="Task details" bind:value={task.details}></textarea>
+    <div class="readonly">Today: {formatDuration(totalToday)}</div>
+    <div class="readonly">Created: {new Date(task.createdAt).toLocaleString()}</div>
+    <div class="tags">
+      {#each [...task.tags].sort() as tag}
+        <span
+          class="tag-pill"
+          draggable="true"
+          on:dragstart={(e: DragEvent) => {
+            e.dataTransfer?.setData('text/tag', tag);
+            removeTag(tag);
+          }}
+          style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[tag]?.fg};border-color:{get(tagStyles)[tag]?.border}"
+          >{tag}</span
+        >
+      {/each}
+    </div>
   {:else}
-    <p>No task selected.</p>
+    <div class="placeholder">
+      <div class="header">
+        <h3>&nbsp;</h3>
+        <span class="time">00:00:00</span>
+      </div>
+      <textarea placeholder="Task details" disabled></textarea>
+      <div class="readonly">Today: 00:00:00</div>
+      <div class="readonly">Created:</div>
+      <div class="tags"></div>
+    </div>
   {/if}
 </section>
 
 <style>
-.advanced-details { padding: 1rem; }
+  .advanced-details {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  textarea {
+    width: 100%;
+    min-height: 4rem;
+  }
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    justify-content: flex-start;
+  }
+  .tag-pill {
+    padding: 0.2rem 0.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--border);
+    font-size: 0.75rem;
+    cursor: grab;
+  }
+  .readonly {
+    font-size: 0.8rem;
+  }
+  .placeholder {
+    visibility: hidden;
+  }
 </style>

--- a/src/lib/components/ClearedList.svelte
+++ b/src/lib/components/ClearedList.svelte
@@ -5,11 +5,10 @@
 </script>
 
 <section class="cleared-list">
-  <h2>Cleared</h2>
   <ul
     on:dragover|preventDefault
-    on:drop={(e) => {
-      const activeId = e.dataTransfer.getData('text/active');
+    on:drop={(e: DragEvent) => {
+      const activeId = e.dataTransfer?.getData('text/active');
       if (activeId) clearTask(activeId);
     }}
   >

--- a/src/lib/components/DayRecap.svelte
+++ b/src/lib/components/DayRecap.svelte
@@ -61,7 +61,6 @@
 
 <section class="day-recap">
   <header>
-    <h2>Recap</h2>
     <input type="date" bind:value={dateString} on:change={onDateChange} />
   </header>
 

--- a/src/lib/components/PageBanner.svelte
+++ b/src/lib/components/PageBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { settings } from '$lib/stores/settings';
   import type { Settings } from '$lib/stores/settings';
+  import { showCleared } from '$lib';
   import { onDestroy } from 'svelte';
 
   let showModal = false;
@@ -29,6 +30,10 @@
     dispatchEvent(event);
   }
 
+  function toggleCleared() {
+    showCleared.update(v => !v);
+  }
+
   onDestroy(unsubscribe);
 </script>
 
@@ -37,7 +42,8 @@
   <div class="actions">
     <button on:click={exportData}>Export</button>
     <button on:click={importData}>Import</button>
-    <button on:click={() => (showModal = true)} title="Settings">⚙️</button>
+    <button on:click={toggleCleared}>{$showCleared ? 'Hide Cleared' : 'Show Cleared'}</button>
+    <button on:click={() => (showModal = true)} title="Settings">⚙️ Settings</button>
   </div>
 </header>
 

--- a/src/lib/components/TagsList.svelte
+++ b/src/lib/components/TagsList.svelte
@@ -31,7 +31,6 @@
 </script>
 
 <section class="tags-list">
-  <h2>Tags</h2>
   <div class="palette">
     {#each tags as tag}
       <span
@@ -39,21 +38,36 @@
         style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[tag]?.fg};border-color:{get(tagStyles)[tag]?.border}"
         draggable="true"
         on:contextmenu|preventDefault={() => startEdit(tag)}
-        on:dragstart={(e) => e.dataTransfer.setData('text/tag', tag)}
+        on:dragstart={(e: DragEvent) => e.dataTransfer?.setData('text/tag', tag)}
         >{tag}</span
       >
     {/each}
   </div>
 
   {#if editTag}
-    <div class="edit-dialog">
-      <input type="text" bind:value={newName} />
-      <input type="color" bind:value={bg} />
-      <input type="color" bind:value={fg} />
-      <input type="color" bind:value={border} />
-      <button on:click={saveEdit}>Save</button>
-      <button on:click={() => (editTag = null)}>Cancel</button>
-    </div>
+    <table class="edit-dialog">
+      <tbody>
+        <tr>
+          <td colspan="2"><input type="text" bind:value={newName} /></td>
+        </tr>
+        <tr>
+          <td>Background</td>
+          <td><input type="color" bind:value={bg} /></td>
+        </tr>
+        <tr>
+          <td>Text</td>
+          <td><input type="color" bind:value={fg} /></td>
+        </tr>
+        <tr>
+          <td>Border</td>
+          <td><input type="color" bind:value={border} /></td>
+        </tr>
+        <tr>
+          <td><button on:click={saveEdit}>Save</button></td>
+          <td><button on:click={() => (editTag = null)}>Cancel</button></td>
+        </tr>
+      </tbody>
+    </table>
   {/if}
 </section>
 
@@ -70,7 +84,16 @@
 }
 .edit-dialog {
   margin-top: 0.5rem;
-  display: flex;
-  gap: 0.25rem;
+  border-collapse: collapse;
+  width: 100%;
+}
+.edit-dialog td {
+  padding: 0.25rem;
+}
+.edit-dialog input[type='color'] {
+  width: 100%;
+}
+.edit-dialog button {
+  width: 100%;
 }
 </style>

--- a/src/lib/components/TodoList.svelte
+++ b/src/lib/components/TodoList.svelte
@@ -20,12 +20,11 @@
 </script>
 
 <section class="todo-list">
-  <h2>To-Do</h2>
   <ul
     on:dragover|preventDefault
-    on:drop={(e) => {
-      const id = e.dataTransfer.getData('text/task');
-      const activeId = e.dataTransfer.getData('text/active');
+    on:drop={(e: DragEvent) => {
+      const id = e.dataTransfer?.getData('text/task');
+      const activeId = e.dataTransfer?.getData('text/active');
       if (id) reorderTodo(id, null);
       if (activeId) deactivateTask(activeId);
     }}
@@ -34,12 +33,12 @@
       <li
         class="task-row"
         draggable="true"
-        on:dragstart={(e) => e.dataTransfer.setData('text/task', t.id)}
+        on:dragstart={(e: DragEvent) => e.dataTransfer?.setData('text/task', t.id)}
         on:dragover|preventDefault={() => {}}
-        on:drop={(e) => {
-          const id = e.dataTransfer.getData('text/task');
+        on:drop={(e: DragEvent) => {
+          const id = e.dataTransfer?.getData('text/task');
           if (id && id !== t.id) reorderTodo(id, t.id);
-          const tag = e.dataTransfer.getData('text/tag');
+          const tag = e.dataTransfer?.getData('text/tag');
           if (tag && !t.tags.includes(tag)) {
             tasksStore.update((list) => {
               const task = list.find((x) => x.id === t.id);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,3 +3,4 @@ export * from './components';
 export * from './stores/settings';
 export * from './stores/tasks';
 export * from "./stores/tagStyles";
+export * from './stores/ui';

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -54,11 +54,12 @@ export const tasks = createTasks();
 export function activateTask(id: string) {
   const now = Date.now();
   tasks.update((list) => {
-    // End any current active task
+    let previous: TodoTask | undefined;
     list.forEach((t) => {
       const last = t.activePeriods[t.activePeriods.length - 1];
       if (last && last.end === null) {
         last.end = now;
+        previous = t;
       }
     });
 
@@ -66,6 +67,14 @@ export function activateTask(id: string) {
     if (task) {
       task.activePeriods.push({ start: now, end: null });
       task.updatedAt = now;
+    }
+
+    if (previous && previous.id !== id) {
+      const idx = list.findIndex((t) => t.id === previous!.id);
+      if (idx > -1) {
+        list.splice(idx, 1);
+        list.unshift(previous!);
+      }
     }
     return [...list];
   });

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+/** Whether the Cleared tasks section is visible */
+export const showCleared = writable(false);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,8 @@
     clearedTasks,
     activeTask,
     selectedDate,
-    tags
+    tags,
+    showCleared
   } from '$lib';
 </script>
 
@@ -34,16 +35,17 @@
 
     <div class="header-row">
       <div class="box-title">TO DO List</div>
-      <button id="cleared-tab-btn" type="button">Cleared</button>
     </div>
     <div class="box todo-list-box">
       <TodoList tasks={$todoTasks} />
     </div>
 
-    <div class="box-title">Cleared</div>
-    <div class="box cleared-box">
-      <ClearedList tasks={$clearedTasks} />
-    </div>
+    {#if $showCleared}
+      <div class="box-title">Cleared</div>
+      <div class="box cleared-box">
+        <ClearedList tasks={$clearedTasks} />
+      </div>
+    {/if}
   </div>
 
   <!-- Right panel: Details and Tags -->
@@ -97,9 +99,12 @@
     padding-left: 0.5rem;
   }
   .active-box,
-  .todo-list-box,
   .cleared-box {
     max-height: 200px;
+    overflow-y: auto;
+  }
+  .todo-list-box {
+    max-height: 30rem;
     overflow-y: auto;
   }
 </style>


### PR DESCRIPTION
## Summary
- implement advanced details panel for active task
- show active task title, running timer and tags
- toggle cleared list from banner
- tidy headings and apply max height to todo list
- add store for UI preferences and update task activation logic
- document core requirements overview

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68509550be9c832a8414ee9acc60f4e3