### PR TITLE
Fix recap panel layout

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,11 @@ The application is structured into these components:
 - Drag‑and‑drop interactions provide clear feedback.
 - The Day Recap timeline updates live while time progresses.
 - The Active item resembles a large list entry with list numbers outside rounded boxes.
+
+## Documentation Core Requirements
+
+The project documentation follows these principles:
+
+- All guides and references live in this `docs` directory.
+- Each README section uses clear headings for quick navigation.
+- Descriptions adopt concise EU English.

--- a/src/lib/components/DayRecap.svelte
+++ b/src/lib/components/DayRecap.svelte
@@ -117,13 +117,21 @@
 <style>
   .recap-timeline {
     position: relative;
+    display: flex;
+    flex-direction: column;
     height: 100%;
     overflow-x: auto;
-    overflow-y: hidden;
+  }
+  .recap-timeline > header {
+    position: sticky;
+    top: 0;
+    background: var(--bg-box);
+    z-index: 1;
   }
   .timeline-wrapper {
     position: relative;
-    height: calc(100% - 1.5rem);
+    flex: 1;
+    overflow-y: auto;
     margin-top: 1.5rem;
   }
   .time-grid {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,10 @@
   let unsubscribe: () => void;
 
   onMount(() => {
+    const banner = document.querySelector('.page-banner') as HTMLElement;
+    if (banner) {
+      document.documentElement.style.setProperty('--header-height', `${banner.offsetHeight}px`);
+    }
     unsubscribe = settings.subscribe(({ theme, tagBorderWidth }) => {
       document.documentElement.classList.toggle('theme-dark', theme === 'dark');
       document.documentElement.classList.toggle('theme-light', theme === 'light');
@@ -22,6 +26,7 @@
 <style>
   :global(:root) {
     --tag-border-width: 2px;
+    --header-height: 70px;
   }
   :global(.theme-light) {
     --bg-panel: #fafbfc;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -107,7 +107,9 @@
   .recap-box {
     flex: 1;
     display: flex;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: calc(100vh - var(--header-height));
   }
   .header-row {
     display: flex;


### PR DESCRIPTION
## Summary
- keep docs short and in EU English
- record header height for viewport-aware sizing
- allow recap chart to scroll without leaving header
- set recap box height relative to the viewport