### PR TITLE
Fix recap box height

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # TODO Timer Dashboard Documentation
 
-This README outlines the interface and lists the core requirements that govern the TODO Timer Dashboard.
+This README summarises the interface, core application rules and the requirements for maintaining these documents. All guidance lives in this single file.
 
 ## Interface Overview
 

--- a/src/lib/components/DayRecap.svelte
+++ b/src/lib/components/DayRecap.svelte
@@ -131,7 +131,7 @@
   .timeline-wrapper {
     position: relative;
     flex: 1;
-    overflow-y: auto;
+    overflow: hidden;
     margin-top: 1.5rem;
   }
   .time-grid {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -82,7 +82,7 @@
     grid-template-columns: 1fr 2fr 1fr;
     gap: 1rem;
     padding: 1rem;
-    min-height: 100vh;
+    height: calc(100vh - var(--header-height));
     background-color: var(--bg-panel);
     color: var(--text-color);
     box-sizing: border-box;
@@ -95,6 +95,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    height: 100%;
+    min-height: 0;
   }
   .box {
     background-color: var(--bg-box);
@@ -107,9 +109,8 @@
   .recap-box {
     flex: 1;
     display: flex;
-    overflow-x: hidden;
-    overflow-y: auto;
-    max-height: calc(100vh - var(--header-height));
+    overflow: hidden;
+    min-height: 0;
   }
   .header-row {
     display: flex;


### PR DESCRIPTION
## Summary
- constrain page grid height to the viewport below the header
- allow panels and recap box to shrink without scrolling
- prevent Recap chart overflow
- document core requirements in docs/README only