### PR TITLE
Extend task controls in active and details views

### DIFF
--- a/src/lib/components/ActiveTask.svelte
+++ b/src/lib/components/ActiveTask.svelte
@@ -6,19 +6,15 @@
     deactivateTask,
     clearTask,
     moveToTop,
-    tagStyles,
     tasks as tasksStore,
-    cyclePriority,
-    PRIORITY_LABELS,
+    renameTask,
+    changeBorder,
+    deleteTask
   } from '$lib';
-  import { get } from 'svelte/store';
-  import { now, getTotalMs, formatMs } from '$lib/timeUtils';
+  import TodoItem from './TodoItem.svelte';
   export let task: TodoTask | null = null;
 
   let showActions = false;
-
-  $: totalMs = task ? getTotalMs(task.activePeriods, $now) : 0;
-  $: displayTime = formatMs(totalMs);
 </script>
 
 <section
@@ -72,25 +68,17 @@
       >
         ✅
       </div>
-      <div class="row">
-        <span
-          class="prio p{task.priority ?? 4}"
-          title={PRIORITY_LABELS[task.priority ?? 4]}
-          on:click={() => cyclePriority(task.id)}
-        ></span>
-        <span class="title">{task.title}</span>
-        <span class="time">{displayTime}</span>
-      </div>
-      <div class="tags">
-        {#each [...task.tags].sort( (a, b) => a.localeCompare( b, undefined, { sensitivity: 'base' }, ), ) as tag}
-          <span
-            class="tag-pill"
-            style="background:{get(tagStyles)[tag]?.bg};color:{get(tagStyles)[
-              tag
-            ]?.fg};border-color:{get(tagStyles)[tag]?.border}">{tag}</span
-          >
-        {/each}
-      </div>
+      <TodoItem
+        task={task}
+        on:dragstart={(e: DragEvent) => {
+          showActions = true;
+          e.dataTransfer?.setData('text/active', task.id);
+        }}
+        on:dragend={() => (showActions = false)}
+        on:rename={(e) => renameTask(e.detail.id, e.detail.newName)}
+        on:changeBorder={(e) => changeBorder(e.detail.id, e.detail.borderColor)}
+        on:delete={(e) => deleteTask(e.detail.id)}
+      />
     </div>
   {:else}
     <p>No active task</p>
@@ -110,47 +98,6 @@
     background: var(--bg-box);
     border: 1px solid var(--border);
     border-radius: 0.25rem;
-  }
-  .row {
-    display: flex;
-    align-items: baseline;
-  }
-  .prio {
-    width: 1rem;
-    height: 1rem;
-    border-radius: 0.2rem;
-    margin-right: 0.5rem;
-    cursor: pointer;
-  }
-  .title {
-    margin-right: auto;
-  }
-  .time {
-    min-width: 8ch;
-  }
-  .p1 {
-    background: #ff5555;
-  }
-  .p2 {
-    background: #ff9900;
-  }
-  .p3 {
-    background: #22aa22;
-  }
-  .p4 {
-    background: #888888;
-  }
-  .tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    justify-content: flex-end;
-  }
-  .tag-pill {
-    padding: 0.1rem 0.3rem;
-    border: var(--tag-border-width, 2px) solid var(--border);
-    border-radius: 0.5rem;
-    font-size: 0.7rem;
   }
 
   .action {

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -188,6 +188,18 @@ export function changeBorder(id: string, borderColor: string) {
   });
 }
 
+export function addTag(id: string, tagName: string) {
+  if (!tagName.match(/^[A-Za-z0-9_-]+$/) || tagName.length > 20) return;
+  tasks.update((list) => {
+    const task = list.find((t) => t.id === id);
+    if (task && !task.tags.includes(tagName)) {
+      task.tags = [...task.tags, tagName];
+      ensureTagStyle(tagName);
+    }
+    return [...list];
+  });
+}
+
 export function deleteTask(id: string) {
   tasks.update((list) => list.filter((t) => t.id !== id));
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,8 @@
     selectedDate,
     tags,
     showCleared,
+    renameTask,
+    addTag,
   } from '$lib';
   import { now, getTotalMs, formatMs } from '$lib/timeUtils';
 
@@ -65,7 +67,11 @@
   <div class="right-panel">
     <div class="box-title">Details</div>
     <div class="box details-box">
-      <AdvancedDetails task={$activeTask} />
+      <AdvancedDetails
+        task={$activeTask}
+        on:rename={(e) => renameTask(e.detail.id, e.detail.newName)}
+        on:addTag={(e) => addTag(e.detail.id, e.detail.tagName)}
+      />
     </div>
     <div class="box-title">Priority</div>
     <div class="box priority-box">


### PR DESCRIPTION
## Summary
- reuse TodoItem in `ActiveTask` so the overflow menu is available
- add inline rename and tag creation features in `AdvancedDetails`
- expose new `addTag` helper in task store
- handle rename and addTag events on the main page