### PR TITLE
Fix active task drag and drop

### DIFF
--- a/src/lib/components/ActiveTask.svelte
+++ b/src/lib/components/ActiveTask.svelte
@@ -19,6 +19,7 @@
 
 <section
   class="active-task"
+  class:has-task={task}
   on:dragover|preventDefault
   on:drop={(e: DragEvent) => {
     const id = e.dataTransfer?.getData('text/task');
@@ -36,6 +37,8 @@
   {#if task}
     <TodoItem
       task={task}
+      interceptDrop={false}
+      compact={true}
       on:dragstart={(e) => {
         showActions = true;
         (e as unknown as DragEvent).dataTransfer?.setData('text/active', task.id);
@@ -86,6 +89,10 @@
     border: 1px solid var(--border);
     border-radius: 0.25rem;
   }
+  .has-task {
+    padding: 0;
+    border: none;
+  }
 
   .action {
     position: absolute;
@@ -97,6 +104,7 @@
     justify-content: center;
     font-size: 1.5rem;
     user-select: none;
+    z-index: 1;
   }
   .drop-left {
     left: 0;

--- a/src/lib/components/TodoItem.svelte
+++ b/src/lib/components/TodoItem.svelte
@@ -14,6 +14,8 @@
   import { formatMs, getTotalMs, now } from '$lib/timeUtils';
 
   export let task: TodoTask;
+  export let interceptDrop = true;
+  export let compact = false;
 
   let titleElement: HTMLSpanElement;
   let rowElement: HTMLLIElement;
@@ -72,12 +74,14 @@
 
 <li
   class="task-row"
+  class:compact={compact}
   bind:this={rowElement}
   {...borderStyleProps}
   draggable="true"
   on:dragstart={(e: DragEvent) => e.dataTransfer?.setData('text/task', task.id)}
   on:dragover|preventDefault={() => {}}
   on:drop={(e: DragEvent) => {
+    if (!interceptDrop) return;
     e.stopPropagation();
     const id = e.dataTransfer?.getData('text/task');
     if (id && id !== task.id) reorderTodo(id, task.id);
@@ -89,8 +93,7 @@
         return [...list];
       });
     }
-  }}
->
+  }}>
   <div class="row">
     <button
       type="button"
@@ -165,6 +168,9 @@
     background: var(--bg-box);
     border: 2px solid var(--task-border, var(--border));
     cursor: grab;
+  }
+  .compact {
+    margin: 0;
   }
   .row {
     display: flex;


### PR DESCRIPTION
## Summary
- support turning off drop handling in `TodoItem`
- adjust `ActiveTask` to allow replacing current task by drop
- remove extra padding/border when active task is present
- expose `compact` style for `TodoItem`