### PR TITLE
Implement escape key cancel actions

### DIFF
--- a/src/lib/components/ActiveTask.svelte
+++ b/src/lib/components/ActiveTask.svelte
@@ -9,6 +9,7 @@
     tasks as tasksStore,
     renameTask,
     changeBorder,
+    resetBorder,
     deleteTask,
   } from '$lib';
   import TodoItem from './TodoItem.svelte';
@@ -75,6 +76,7 @@
         useThemeBorder={true}
         on:rename={(e) => renameTask(e.detail.id, e.detail.newName)}
         on:changeBorder={(e) => changeBorder(e.detail.id, e.detail.borderColor)}
+        on:resetBorder={(e) => resetBorder(e.detail.id)}
         on:delete={(e) => deleteTask(e.detail.id)}
       />
       <div

--- a/src/lib/components/AdvancedDetails.svelte
+++ b/src/lib/components/AdvancedDetails.svelte
@@ -22,6 +22,7 @@
   let addingTag = false;
   let newTag = '';
   const MAX_TAG_LENGTH = 20;
+  let draftDetails = '';
 
   $: totalMs = task ? getTotalMs(task.activePeriods, $now) : 0;
   $: displayTime = formatMs(totalMs);
@@ -112,7 +113,13 @@
           class="title-input"
           bind:value={draftTitle}
           on:blur={commitTitle}
-          on:keydown={(e) => e.key === 'Enter' && commitTitle()}
+          on:keydown={(e) => {
+            if (e.key === 'Enter') commitTitle();
+            if (e.key === 'Escape') {
+              editingTitle = false;
+              draftTitle = task.title;
+            }
+          }}
         />
       {:else}
         <h3>{task.title}</h3>
@@ -125,7 +132,17 @@
         >✎</button>
       {/if}
     </div>
-    <textarea placeholder="Task details" bind:value={task.details}></textarea>
+    <textarea
+      placeholder="Task details"
+      bind:value={task.details}
+      on:focus={() => (draftDetails = task.details ?? '')}
+      on:keydown={(e) => {
+        if (e.key === 'Escape') {
+          task.details = draftDetails;
+          (e.target as HTMLTextAreaElement).blur();
+        }
+      }}
+    ></textarea>
     <div class="readonly">Today: {displayTime}</div>
     {#each lastDaysTotals as { date, duration }}
       <div class="readonly">
@@ -163,7 +180,13 @@
           class="tag-pill tag-input"
           bind:value={newTag}
           on:blur={commitTag}
-          on:keydown={(e) => e.key === 'Enter' && commitTag()}
+          on:keydown={(e) => {
+            if (e.key === 'Enter') commitTag();
+            if (e.key === 'Escape') {
+              addingTag = false;
+              newTag = '';
+            }
+          }}
         />
       {:else}
         <button type="button" class="tag-pill add-tag" on:click={startAddTag}>[+]</button>

--- a/src/lib/components/TagsList.svelte
+++ b/src/lib/components/TagsList.svelte
@@ -82,7 +82,10 @@
   {/if}
 
   {#if editTag}
-    <table class="edit-dialog">
+    <table
+      class="edit-dialog"
+      on:keydown={(e) => e.key === 'Escape' && (editTag = null)}
+    >
       <tbody>
         <tr>
           <td colspan="2"><input type="text" bind:value={newName} /></td>

--- a/src/lib/components/TodoItem.svelte
+++ b/src/lib/components/TodoItem.svelte
@@ -109,7 +109,13 @@
         bind:this={titleElement}
         bind:value={draftTitle}
         on:blur={commitRename}
-        on:keydown={(e) => e.key === 'Enter' && commitRename()}
+        on:keydown={(e) => {
+          if (e.key === 'Enter') commitRename();
+          if (e.key === 'Escape') {
+            editingTitle = false;
+            draftTitle = task.title;
+          }
+        }}
       />
     {:else}
       <span class="title" bind:this={titleElement} on:dblclick={startRename}>{task.title}</span>
@@ -148,10 +154,18 @@
           bind:value={draftBorderColor}
           on:change={applyBorder}
           on:blur={() => (menuOpen = false)}
+          on:keydown={(e) => {
+            if (e.key === 'Escape') {
+              showColorPicker = false;
+              menuOpen = false;
+              draftBorderColor = task.borderColor || '#000000';
+            }
+          }}
         />
       {:else}
         <button type="button" on:click={startRename}>Rename</button>
         <button type="button" on:click={openColorPicker}>Change border</button>
+        <button type="button" on:click={() => dispatch('resetBorder', { id: task.id })}>Reset border</button>
         <div class="separator"></div>
         <button type="button" on:click={deleteTask}>Delete</button>
       {/if}

--- a/src/lib/components/TodoList.svelte
+++ b/src/lib/components/TodoList.svelte
@@ -6,6 +6,7 @@
     reorderTodo,
     renameTask,
     changeBorder,
+    resetBorder,
     deleteTask as removeTask,
     addTag
   } from '$lib';
@@ -43,6 +44,7 @@
           interceptDrop={false}
           on:rename={(e) => renameTask(e.detail.id, e.detail.newName)}
           on:changeBorder={(e) => changeBorder(e.detail.id, e.detail.borderColor)}
+          on:resetBorder={(e) => resetBorder(e.detail.id)}
           on:delete={(e) => removeTask(e.detail.id)}
         />
       {/each}

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -188,6 +188,17 @@ export function changeBorder(id: string, borderColor: string) {
   });
 }
 
+export function resetBorder(id: string) {
+  tasks.update((list) => {
+    const task = list.find((t) => t.id === id);
+    if (task) {
+      delete task.borderColor;
+      task.updatedAt = Date.now();
+    }
+    return [...list];
+  });
+}
+
 export function addTag(id: string, tagName: string) {
   if (!tagName.match(/^[A-Za-z0-9_-]+$/) || tagName.length > 20) return;
   tasks.update((list) => {


### PR DESCRIPTION
## Summary
- add new `resetBorder` action on tasks
- add Escape key handling for renaming and color picking in to-do items
- allow cancelling edits in advanced details view
- allow Escape to exit tag edit dialogs
- expose reset border action in UI