### PR TITLE
Refactor time display and add end-of-day reorder

### DIFF
--- a/src/lib/components/AdvancedDetails.svelte
+++ b/src/lib/components/AdvancedDetails.svelte
@@ -11,7 +11,7 @@
   import { createEventDispatcher } from 'svelte';
   import {
     now,
-    getTotalMs,
+    getTotalActiveMs,
     formatMs,
     getLastDaysTotals,
     dayBoundary,
@@ -29,7 +29,7 @@
   const MAX_TAG_LENGTH = 20;
   let draftDetails = '';
 
-  $: totalMs = task ? getTotalMs(task.activePeriods, $now) : 0;
+  $: totalMs = task ? getTotalActiveMs(task.activePeriods, $now) : 0;
   $: displayTime = formatMs(totalMs);
 
   // raw totals for the last N days (excluding today)

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -78,6 +78,10 @@
           Show List Numbers:
           <input type="checkbox" bind:checked={localSettings.showListNumbers} />
         </label>
+        <label>
+          Move Active Task on Day End:
+          <input type="checkbox" bind:checked={localSettings.reorderAtDayEnd} />
+        </label>
         <div class="form-buttons">
           <button type="button" on:click={exportData}>Export</button>
           <button type="button" on:click={importData}>Import</button>

--- a/src/lib/components/TodoItem.svelte
+++ b/src/lib/components/TodoItem.svelte
@@ -5,7 +5,7 @@
   import type { TodoTask } from '$lib/types';
   import { reorderTodo, cyclePriority, tagStyles, tasks, PRIORITY_LABELS } from '$lib';
   import { clickOutside } from '$lib/actions/clickOutside';
-  import { formatMs, getTotalMs, now } from '$lib/timeUtils';
+  import { formatMs, getTotalActiveMs, now } from '$lib/timeUtils';
 
   export let task: TodoTask;
   export let interceptDrop = true;
@@ -137,7 +137,7 @@
     >
       ⋮
     </button>
-    <span class="time">{formatMs(getTotalMs(task.activePeriods, $now))}</span>
+    <span class="time">{formatMs(getTotalActiveMs(task.activePeriods, $now))}</span>
   </div>
   <div class="tags">
     {#each [...task.tags].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })) as tag}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -21,6 +21,7 @@ export interface Settings {
   | 'theme-autumn';
   tagBorderWidth: number;
   showListNumbers: boolean;
+  reorderAtDayEnd: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -29,7 +30,8 @@ const DEFAULT_SETTINGS: Settings = {
   dayEnd: '18:00',
   theme: 'dark',
   tagBorderWidth: 2,
-  showListNumbers: true
+  showListNumbers: true,
+  reorderAtDayEnd: false
 };
 
 function createSettings() {

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -1,8 +1,10 @@
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import type { TodoTask } from '$lib/types';
 import { ensureTagStyle } from './tagStyles';
 import { tagFilter, tagFilterAnd, priorityFilter } from './ui';
+import { settings } from './settings';
+import { dayEndBoundary } from '$lib/timeUtils';
 
 /** Parse an input string and extract tags prefixed with '#'.
  * Returns the cleaned title and array of tags.
@@ -261,3 +263,10 @@ export const tags = derived(tasks, ($tasks) => {
 });
 
 export const selectedDate = writable(new Date());
+
+dayEndBoundary.subscribe(() => {
+  if (get(settings).reorderAtDayEnd) {
+    const active = get(activeTask);
+    if (active) moveToTop(active.id);
+  }
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,7 +19,7 @@
     renameTask,
     addTag,
   } from '$lib';
-  import { now, getTotalMs, formatMs } from '$lib/timeUtils';
+  import { now } from '$lib/timeUtils';
 
 </script>
 


### PR DESCRIPTION
## Summary
- track day end with a new `dayEndBoundary` store and allow summing active time without day bounds
- display total active time for todo items and advanced details
- add a setting to move the active task to the top when the day ends
- automatically reorder active task at day end if enabled